### PR TITLE
Add TLS configuration.

### DIFF
--- a/tls.yml
+++ b/tls.yml
@@ -1,0 +1,12 @@
+# For latest security configuration standards see https://ssl-config.mozilla.org/
+tls:
+  options:
+    intermediate:
+      minVersion: VersionTLS12
+      cipherSuites:
+        - TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        - TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        - TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305
+        - TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305

--- a/traefik.yml
+++ b/traefik.yml
@@ -14,7 +14,7 @@ services:
       - target: 443
         published: 443
         mode: host
-    deploy: 
+    deploy:
       placement:
         constraints:
           - node.labels.traefik-public.traefik-public-certificates == true
@@ -41,11 +41,11 @@ services:
         # Uses the environment variable DOMAIN
         - traefik.http.routers.traefik-public-https.rule=Host(`${DOMAIN?Variable not set}`)
         - traefik.http.routers.traefik-public-https.entrypoints=https
-        - traefik.http.routers.traefik-public-https.tls=true
-        # Use the special Traefik service api@internal with the web UI/Dashboard
-        - traefik.http.routers.traefik-public-https.service=api@internal
+        - traefik.http.routers.traefik-public-https.tls.options=intermediate@file
         # Use the "le" (Let's Encrypt) resolver created below
         - traefik.http.routers.traefik-public-https.tls.certresolver=le
+        # Use the special Traefik service api@internal with the web UI/Dashboard
+        - traefik.http.routers.traefik-public-https.service=api@internal
         # Enable HTTP Basic auth, using the middleware created above
         - traefik.http.routers.traefik-public-https.middlewares=admin-auth
         # Define the port inside of the Docker service to use
@@ -55,6 +55,7 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       # Mount the volume to store the certificates
       - traefik-public-certificates:/certificates
+      - ${PWD}/tls.yml:/config/tls.yml
     command:
       # Enable Docker in Traefik, so that it reads labels from Docker services
       - --providers.docker
@@ -64,6 +65,8 @@ services:
       - --providers.docker.exposedbydefault=false
       # Enable Docker Swarm mode
       - --providers.docker.swarmmode
+      # Config files location
+      - --providers.file.directory=/config/
       # Create an entrypoint "http" listening on port 80
       - --entrypoints.http.address=:80
       - --entrypoints.http.http.redirections.entryPoint.to=https

--- a/traefik.yml
+++ b/traefik.yml
@@ -32,6 +32,10 @@ services:
         # It can be re-used by other stacks in other Docker Compose files
         - traefik.http.middlewares.https-redirect.redirectscheme.scheme=https
         - traefik.http.middlewares.https-redirect.redirectscheme.permanent=true
+        # https-header middleware to add security headers (e.g. HSTS policy)
+        # It can be re-used by other stacks in other Docker Compose files
+        # HSTS max-age=63072000
+        - traefik.http.middlewares.https-header.headers.stsSeconds=63072000
         # traefik-http set up only to use the middleware to redirect to https
         # Uses the environment variable DOMAIN
         - traefik.http.routers.traefik-public-http.rule=Host(`${DOMAIN?Variable not set}`)
@@ -47,7 +51,7 @@ services:
         # Use the special Traefik service api@internal with the web UI/Dashboard
         - traefik.http.routers.traefik-public-https.service=api@internal
         # Enable HTTP Basic auth, using the middleware created above
-        - traefik.http.routers.traefik-public-https.middlewares=admin-auth
+        - traefik.http.routers.traefik-public-https.middlewares=admin-auth,https-header
         # Define the port inside of the Docker service to use
         - traefik.http.services.traefik-public.loadbalancer.server.port=8080
     volumes:


### PR DESCRIPTION
Adding TLS configuration following latests security guidelines (see https://ssl-config.mozilla.org/#server=traefik&version=2.1.2&config=intermediate&guideline=5.6):
* Minimum TLS version 1.2
* Cipher suites aimed for general compatibility supported by most browsers ("intermediate" in Mozilla config generator)
* HTTP Strict-Transport-Security header: max-age set to 2 years to make client browsers remember that the site should be
accessed by https by default.

@aeifn, I have no means to test this change, please take extra care when deploying 😉 